### PR TITLE
add create action step

### DIFF
--- a/pages/api/create-action.ts
+++ b/pages/api/create-action.ts
@@ -1,0 +1,91 @@
+import { NextApiRequest, NextApiResponse } from 'next'
+import { getServerSession } from 'next-auth'
+import { baseAuthOptions } from './auth/[...nextauth]'
+
+export enum CreateActionErrorCodes {
+  Unauthorized = 'unauthorized',
+  InternalServerError = 'internal_server_error',
+  AlreadyExists = 'already_exists',
+}
+
+export const createActionErrorMessages = {
+  [CreateActionErrorCodes.Unauthorized]: 'Unauthorized',
+  [CreateActionErrorCodes.InternalServerError]: 'Something went wrong.',
+  [CreateActionErrorCodes.AlreadyExists]: 'This action already exists.',
+}
+
+export type CreateActionReturnType =
+  | {
+      success: true
+    }
+  | {
+      success: false
+      code: CreateActionErrorCodes
+      message: string
+    }
+
+export const createAction = async (req: NextApiRequest, res: NextApiResponse<CreateActionReturnType>) => {
+  if (!process.env.DEVELOPER_PORTAL_URL || !process.env.APP_ID || !process.env.NEXT_SERVER_DEV_PORTAL_API_KEY) {
+    console.log('Environment variables for /create-action endpoint are missing.')
+
+    return res.status(500).json({
+      success: false,
+      code: CreateActionErrorCodes.InternalServerError,
+      message: createActionErrorMessages[CreateActionErrorCodes.InternalServerError],
+    })
+  }
+
+  const session = await getServerSession(req, res, baseAuthOptions)
+
+  if (!session || !session.user.guildId) {
+    return res.status(401).json({
+      success: false,
+      code: CreateActionErrorCodes.Unauthorized,
+      message: createActionErrorMessages[CreateActionErrorCodes.Unauthorized],
+    })
+  }
+
+  const guildId = session.user.guildId
+
+  const createActionResponse = await fetch(
+    `${process.env.DEVELOPER_PORTAL_URL}/api/v2/create-action/${process.env.APP_ID}`,
+    {
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `ApiKey ${process.env.NEXT_SERVER_DEV_PORTAL_API_KEY}`,
+      },
+
+      body: JSON.stringify({
+        action: guildId,
+        name: `discord-integration-${guildId}`,
+        description: `Discord integration for the guildId: ${guildId}`,
+      }),
+    },
+  )
+
+  let body: any | null = null
+
+  try {
+    body = await createActionResponse.json()
+  } catch (error) {
+    console.log('Error while parsing the response from the Developer Portal API:', error)
+  }
+
+  if (createActionResponse.status === 400 && body && body.code === 'constraint-violation') {
+    return res.status(200).json({
+      success: false,
+      code: CreateActionErrorCodes.AlreadyExists,
+      message: createActionErrorMessages[CreateActionErrorCodes.AlreadyExists],
+    })
+  }
+
+  if (createActionResponse.status !== 200) {
+    return res.status(500).json({
+      success: false,
+      code: CreateActionErrorCodes.InternalServerError,
+      message: createActionErrorMessages[CreateActionErrorCodes.InternalServerError],
+    })
+  }
+
+  return res.status(200).json({ success: true })
+}

--- a/pages/api/create-action.ts
+++ b/pages/api/create-action.ts
@@ -26,7 +26,7 @@ export type CreateActionReturnType =
     }
 
 const createAction = async (req: NextApiRequest, res: NextApiResponse<CreateActionReturnType>) => {
-  if (!process.env.DEVELOPER_PORTAL_URL || !process.env.APP_ID || !process.env.NEXT_SERVER_DEV_PORTAL_API_KEY) {
+  if (!process.env.DEVELOPER_PORTAL_URL || !process.env.APP_ID || !process.env.DEVELOPER_PORTAL_API_KEY) {
     console.log('Environment variables for /create-action endpoint are missing.')
 
     return res.status(500).json({
@@ -55,7 +55,7 @@ const createAction = async (req: NextApiRequest, res: NextApiResponse<CreateActi
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        Authorization: `ApiKey ${process.env.NEXT_SERVER_DEV_PORTAL_API_KEY}`,
+        Authorization: `ApiKey ${process.env.DEVELOPER_PORTAL_API_KEY}`,
       },
 
       body: JSON.stringify({


### PR DESCRIPTION
Now on saving guild configuration we automatically create action for this guild to avoid precheck fail.
- Adds new `NEXT_SERVER_DEV_PORTAL_API_KEY` env.

--- 

<details> 
<summary>Result</summary>


Action created on config save: 

<img width="1246" alt="image" src="https://github.com/worldcoin/world-id-discord/assets/89008845/76aea09d-3526-4e88-b0b9-77037ba4c153">

If action is already created: 
<img width="1686" alt="image" src="https://github.com/worldcoin/world-id-discord/assets/89008845/e08397f0-051c-4de1-a688-8c519931ce6b">

Verification is successful: 
<img width="645" alt="image" src="https://github.com/worldcoin/world-id-discord/assets/89008845/117fca2c-4486-4ab7-89fb-fac4d9b164c1">


</details>
