### PR TITLE
Add live Discord permission check for admin endpoints

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,6 @@
     "source.fixAll.eslint": "explicit"
   },
 
-  "eslint.useFlatConfig": true
+  "eslint.useFlatConfig": true,
+  "i18n-ally.localesPaths": ["i18n", "messages"]
 }

--- a/app/[locale]/admin/page.tsx
+++ b/app/[locale]/admin/page.tsx
@@ -7,6 +7,7 @@ import { VerificationLevels } from '@/features/admin/components/VerificationLeve
 import { ConfigForm } from '@/features/admin/providers/ConfigForm'
 import { fetchBotConfig } from '@/lib/discord-integration-api/fetch-bot-config'
 import { fetchAvailableGuildRoles } from '@/lib/discord/fetch-available-guild-roles'
+import { userIsGuildAdmin } from '@/lib/discord/user-is-guild-admin'
 import { authOptions } from '@/server/auth-options'
 import { generateMetaTitle } from '@/utils/generate-meta-title'
 import { prepareConfigFormInitialValues } from '@/utils/prepare-ui-bot-config'
@@ -23,17 +24,25 @@ export const generateMetadata = async () => {
 const Admin = async () => {
   const session = await getServerSession(authOptions)
 
-  if (!session?.guild.id) {
+  if (!session?.user?.id || !session?.guild?.id) {
     redirect(routes.signIn({ callbackUrl: routes.admin() }))
   }
 
-  const roles = await fetchAvailableGuildRoles(session?.guild.id)
-  const botConfig = await fetchBotConfig(session?.guild.id)
+  const isAdmin = await userIsGuildAdmin(session.user.id, session.guild.id).catch(() => false)
+
+  if (!isAdmin) {
+    redirect(routes.signIn({ callbackUrl: routes.admin() }))
+  }
+
+  const guildId = session.guild.id
+
+  const roles = await fetchAvailableGuildRoles(guildId)
+  const botConfig = await fetchBotConfig(guildId)
 
   const initialConfigFormValues = prepareConfigFormInitialValues({
     botConfig,
     roles,
-    guild_id: session?.guild.id,
+    guild_id: guildId,
   })
 
   return (

--- a/app/api/admin/bot-config/route.ts
+++ b/app/api/admin/bot-config/route.ts
@@ -1,19 +1,18 @@
 import { fetchBotConfig } from '@/lib/discord-integration-api/fetch-bot-config'
 import { saveBotConfig } from '@/lib/discord-integration-api/save-bot-config'
-import { authOptions } from '@/server/auth-options'
 import { BotConfig } from '@/schemas/bot-config'
+import { ConfigFormValues } from '@/schemas/config-form'
+import { requireGuildAdmin } from '@/server/require-guild-admin'
 import { internalErrorResponse } from '@/utils/error-response'
 import { genericError } from '@/utils/generic-errors'
 import { safeCall } from '@/utils/safe-call'
-import { getServerSession } from 'next-auth'
 import { NextResponse } from 'next/server'
-import { ConfigFormValues } from '@/schemas/config-form'
 
 export const GET = async () => {
-  const session = await getServerSession(authOptions)
+  const guard = await requireGuildAdmin()
 
-  if (!session || !session.user || !session.guild.id) {
-    return internalErrorResponse(genericError.unauthorized)
+  if (!guard.authorized) {
+    return guard.response
   }
 
   if (!process.env.DISCORD_INTEGRATION_API_URL) {
@@ -24,7 +23,7 @@ export const GET = async () => {
     success: fetchBotConfigSuccess,
     data: botConfig,
     error: fetchBotConfigError,
-  } = await safeCall(fetchBotConfig)(session.guild.id)
+  } = await safeCall(fetchBotConfig)(guard.guildId)
 
   if (!fetchBotConfigSuccess) {
     return internalErrorResponse({ message: fetchBotConfigError.message, code: 500 })
@@ -34,16 +33,16 @@ export const GET = async () => {
 }
 
 export const POST = async (request: Request) => {
-  const session = await getServerSession(authOptions)
+  const guard = await requireGuildAdmin()
 
-  if (!session || !session.user || !session.guild.id) {
-    return internalErrorResponse(genericError.unauthorized)
+  if (!guard.authorized) {
+    return guard.response
   }
 
   const body = (await request.json()) as ConfigFormValues
 
   const botConfig: BotConfig = {
-    guild_id: session.guild.id,
+    guild_id: guard.guildId,
     enabled: body.botEnabled,
 
     device: {
@@ -58,7 +57,7 @@ export const POST = async (request: Request) => {
   }
 
   const { success, error } = await safeCall(saveBotConfig)({
-    guildId: session.guild.id,
+    guildId: guard.guildId,
     botConfig,
   })
 

--- a/app/api/admin/create-action/route.ts
+++ b/app/api/admin/create-action/route.ts
@@ -2,10 +2,9 @@ import {
   CreateActionErrorCode,
   DevPortalCreateActionResponse,
 } from '@/features/admin/types/create-action'
-import { authOptions } from '@/server/auth-options'
+import { requireGuildAdmin } from '@/server/require-guild-admin'
 import { internalErrorResponse } from '@/utils/error-response'
 import { genericError } from '@/utils/generic-errors'
-import { getServerSession } from 'next-auth'
 import { NextResponse } from 'next/server'
 
 const DEVELOPER_PORTAL_URL = process.env.DEVELOPER_PORTAL_URL
@@ -17,13 +16,13 @@ export const POST = async () => {
     return internalErrorResponse(genericError.environmentIsMisconfigured)
   }
 
-  const session = await getServerSession(authOptions)
+  const guard = await requireGuildAdmin()
 
-  if (!session?.guild.id) {
-    return internalErrorResponse(genericError.unauthorized)
+  if (!guard.authorized) {
+    return guard.response
   }
 
-  const guildId = session.guild.id
+  const { guildId } = guard
 
   let createActionResponse: DevPortalCreateActionResponse | null = null
 
@@ -60,7 +59,6 @@ export const POST = async () => {
 
   if (!('action' in createActionResponse)) {
     if (createActionResponse.code === CreateActionErrorCode.ConstraintViolation) {
-      // NOTE: Action is already exists, so we can return success
       return NextResponse.json({ success: true })
     }
 

--- a/app/api/admin/roles/route.ts
+++ b/app/api/admin/roles/route.ts
@@ -1,20 +1,17 @@
 import { fetchAvailableGuildRoles } from '@/lib/discord/fetch-available-guild-roles'
-import { authOptions } from '@/server/auth-options'
+import { requireGuildAdmin } from '@/server/require-guild-admin'
 import { internalErrorResponse } from '@/utils/error-response'
-import { genericError } from '@/utils/generic-errors'
-
-import { getServerSession } from 'next-auth'
 import { NextResponse } from 'next/server'
 
 export const GET = async () => {
-  const session = await getServerSession(authOptions)
+  const guard = await requireGuildAdmin()
 
-  if (!session || !session.user || !session.guild.id) {
-    return internalErrorResponse(genericError.unauthorized)
+  if (!guard.authorized) {
+    return guard.response
   }
 
   try {
-    const roles = await fetchAvailableGuildRoles(session.guild.id)
+    const roles = await fetchAvailableGuildRoles(guard.guildId)
     return NextResponse.json(roles)
   } catch (error) {
     console.error('Error fetching roles', error)

--- a/lib/discord/user-is-guild-admin.ts
+++ b/lib/discord/user-is-guild-admin.ts
@@ -1,0 +1,30 @@
+import { APIGuildMember, PermissionFlagsBits, Routes } from 'discord-api-types/v10'
+import { discordRestApi } from './discord-rest-api'
+import { getGuildData } from './get-guild-data'
+
+export const userIsGuildAdmin = async (
+  userId: string,
+  guildId: string
+): Promise<boolean> => {
+  const [guild, member] = await Promise.all([
+    getGuildData(guildId),
+    discordRestApi.get(Routes.guildMember(guildId, userId)) as Promise<APIGuildMember>,
+  ])
+
+  if (guild.owner_id === userId) {
+    return true
+  }
+
+  const everyoneRole = guild.roles.find(role => role.id === guildId)
+  let permissions = BigInt(everyoneRole?.permissions ?? '0')
+
+  for (const roleId of member.roles) {
+    const role = guild.roles.find(r => r.id === roleId)
+
+    if (role) {
+      permissions |= BigInt(role.permissions)
+    }
+  }
+
+  return (permissions & PermissionFlagsBits.Administrator) === PermissionFlagsBits.Administrator
+}

--- a/lib/discord/user-is-guild-admin.ts
+++ b/lib/discord/user-is-guild-admin.ts
@@ -26,5 +26,8 @@ export const userIsGuildAdmin = async (
     }
   }
 
-  return (permissions & PermissionFlagsBits.Administrator) === PermissionFlagsBits.Administrator
+  const allowedGuildManagementPermissions =
+    PermissionFlagsBits.Administrator | PermissionFlagsBits.ManageGuild
+
+  return (permissions & allowedGuildManagementPermissions) !== BigInt(0)
 }

--- a/server/auth-options.ts
+++ b/server/auth-options.ts
@@ -50,6 +50,8 @@ export const authOptions: AuthOptions = {
     },
 
     async session({ session, token }) {
+      session.user.id = token.sub
+
       const guildId = token.guildId
 
       if (guildId) {

--- a/server/require-guild-admin.ts
+++ b/server/require-guild-admin.ts
@@ -1,0 +1,35 @@
+import { userIsGuildAdmin } from '@/lib/discord/user-is-guild-admin'
+import { internalErrorResponse } from '@/utils/error-response'
+import { genericError } from '@/utils/generic-errors'
+import { Session } from 'next-auth'
+import { getServerSession } from 'next-auth'
+import { NextResponse } from 'next/server'
+import { authOptions } from './auth-options'
+
+type AdminGuardSuccess = { authorized: true; session: Session; guildId: string }
+type AdminGuardFailure = { authorized: false; response: NextResponse }
+export type AdminGuardResult = AdminGuardSuccess | AdminGuardFailure
+
+export const requireGuildAdmin = async (): Promise<AdminGuardResult> => {
+  const session = await getServerSession(authOptions)
+
+  if (!session?.user?.id || !session?.guild?.id) {
+    return { authorized: false, response: internalErrorResponse(genericError.unauthorized) }
+  }
+
+  const { id: userId } = session.user
+  const { id: guildId } = session.guild
+
+  try {
+    const isAdmin = await userIsGuildAdmin(userId, guildId)
+
+    if (!isAdmin) {
+      return { authorized: false, response: internalErrorResponse(genericError.forbidden) }
+    }
+  } catch (error) {
+    console.error('Failed to verify guild admin permissions', error)
+    return { authorized: false, response: internalErrorResponse(genericError.forbidden) }
+  }
+
+  return { authorized: true, session, guildId }
+}

--- a/utils/generic-errors.ts
+++ b/utils/generic-errors.ts
@@ -1,5 +1,6 @@
 export const genericError = {
   unauthorized: { message: 'Unauthorized', code: 401 },
+  forbidden: { message: 'Forbidden', code: 403 },
 
   environmentIsMisconfigured: {
     message: 'Environment is misconfigured',


### PR DESCRIPTION
- Every admin API request now verifies the user's current Discord permissions via bot token (guild member + role bitfields)
- Access requires ADMINISTRATOR permission or guild ownership
- Shared guard `requireGuildAdmin()` replaces per-route session checks
- Returns 403 if permissions are insufficient or unverifiable
- Same check applied to server-rendered admin page