### PR TITLE
Use server-side app ID for cloud proof verification

### DIFF
--- a/app/api/verification/complete/route.ts
+++ b/app/api/verification/complete/route.ts
@@ -35,7 +35,15 @@ export const POST = async (request: NextRequest) => {
     })
   }
 
-  const { appId, guildId, userId, token, result, interactionsToken } = body
+  const { guildId, userId, token, result, interactionsToken } = body
+
+  if (!process.env.NEXT_PUBLIC_APP_ID) {
+    return sendDiscordErrorMessageResponse({
+      token: originalBody?.token,
+      code: 500,
+      message: t('Discord_Integration_Complete_Verification_Body_Error'),
+    })
+  }
 
   try {
     await verifyInteractionsToken({
@@ -170,7 +178,12 @@ export const POST = async (request: NextRequest) => {
   let cloudProofVerificationResult: IVerifyResponse | null = null
 
   try {
-    cloudProofVerificationResult = await verifyCloudProof(result, appId, guildId, userId)
+    cloudProofVerificationResult = await verifyCloudProof(
+      result,
+      process.env.NEXT_PUBLIC_APP_ID,
+      guildId,
+      userId
+    )
   } catch (error) {
     console.error('Error verifying proof', error)
 

--- a/features/verification/components/VerificationScreen.tsx
+++ b/features/verification/components/VerificationScreen.tsx
@@ -72,7 +72,6 @@ export const VerificationScreen = ({ configFormValues, guild }: VerificationScre
     }
 
     const input: VerificationCompleteInput = {
-      appId: process.env.NEXT_PUBLIC_APP_ID! as `app_${string}`,
       guildId,
       userId,
       token,

--- a/schemas/verification-complete.ts
+++ b/schemas/verification-complete.ts
@@ -2,7 +2,6 @@ import { VerificationLevel } from '@worldcoin/idkit-core'
 import { z } from 'zod'
 
 export const verificationCompleteInputSchema = z.object({
-  appId: z.string().refine((value): value is `app_${string}` => value.startsWith('app_')),
   guildId: z.string(),
   userId: z.string(),
   token: z.string(),


### PR DESCRIPTION
Switched `verifyCloudProof` to source appId from `process.env.NEXT_PUBLIC_APP_ID` on the server instead of accepting it from the client request body. Removed `appId` from the verification input schema and client payload as it's no longer needed.

