### PR TITLE
chore(ci): update CI workflow triggers and add dependabot cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,8 @@ updates:
       interval: 'monthly'
       time: '06:30'
       timezone: 'UTC'
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 1
     commit-message:
       prefix: 'chore(ci-deps)'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,8 @@ jobs:
       github.event.pull_request.user.id == 49699333 ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.author_association == 'COLLABORATOR'
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.event.pull_request.author_association == 'CONTRIBUTOR'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
@@ -47,7 +48,8 @@ jobs:
       github.event.pull_request.user.id == 49699333 ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'MEMBER' ||
-      github.event.pull_request.author_association == 'COLLABORATOR'
+      github.event.pull_request.author_association == 'COLLABORATOR' ||
+      github.event.pull_request.author_association == 'CONTRIBUTOR'
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:
@@ -12,7 +12,7 @@ jobs:
     name: Source code formatting & spellcheck
     runs-on: ubuntu-24.04
     if: >
-      github.actor == 'dependabot[bot]' ||
+      github.event.pull_request.user.id == 49699333 ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'MEMBER' ||
       github.event.pull_request.author_association == 'COLLABORATOR'
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
 
@@ -43,7 +44,7 @@ jobs:
     name: Typecheck & linting
     runs-on: ubuntu-24.04
     if: >
-      github.actor == 'dependabot[bot]' ||
+      github.event.pull_request.user.id == 49699333 ||
       github.event.pull_request.author_association == 'OWNER' ||
       github.event.pull_request.author_association == 'MEMBER' ||
       github.event.pull_request.author_association == 'COLLABORATOR'
@@ -51,6 +52,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
 
       - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda
 

--- a/cspell.json
+++ b/cspell.json
@@ -12,5 +12,6 @@
     "yaml",
     "json"
   ],
-  "words": ["bgblur", "cmdk", "formatjs", "idkit", "merkle"]
+  "words": ["bgblur", "cmdk", "formatjs", "idkit", "merkle"],
+  "ignorePaths": ["package.json", "node_modules", ".next"]
 }


### PR DESCRIPTION
- Changed the CI workflow trigger from `pull_request_target` to `pull_request`.
- Updated the conditions for running jobs to include specific user ID.
- Added `persist-credentials: false` to the checkout action.
- Introduced a cooldown period of 7 days for dependabot updates in the configuration.